### PR TITLE
Small standardizations to the mdict css

### DIFF
--- a/data/mdict/css/daijirin2.css
+++ b/data/mdict/css/daijirin2.css
@@ -10,10 +10,10 @@
 }
 
 body {
-    margin: 0em 1em;
+    /*margin: 0em 1em;*/
     line-height: 1.5em;
     font-family: jpmincho, serif;
-    font-size: 1.2em;
+    /*font-size: 1.2em;*/
     color: black;
 }
 

--- a/data/mdict/css/sankoku8.css
+++ b/data/mdict/css/sankoku8.css
@@ -15,10 +15,10 @@
 }
 
 body {
-    margin: 0em 1em;
+    /*margin: 0em 1em;*/
     line-height: 1.5em;
     font-family: jpmincho, serif;
-    font-size: 1.2em;
+    /*font-size: 1.2em;*/
 }
 
 span[data-name="entry-index"] > a {

--- a/data/mdict/css/smk8.css
+++ b/data/mdict/css/smk8.css
@@ -10,10 +10,10 @@
 }
 
 body {
-    margin: 0em 1em;
+    /*margin: 0em 1em;*/
     line-height: 1.5em;
     font-family: jpmincho, serif;
-    font-size: 1.2em;
+    /*font-size: 1.2em;*/
     color: black;
 }
 
@@ -26,7 +26,7 @@ span[data-name="見出部"] {
 }
 
 span[data-name="見出部"].pri {
-    margin-left: -0.4em;
+    /*margin-left: -0.4em;*/
 }
 
 span[data-name="見出仮名"] {


### PR DESCRIPTION
I have adjusted the font size and removed the margin. The issue we talked about where entries in smk8 are forced outside the frame is caused by a negative margin for 見出部. sankoku contains the same functionality with stars with doesn't have the negative margin implemented for some reason so no issue there. No issues have been experienced.