### PR TITLE
Add 游明朝/游ゴシック as default font

### DIFF
--- a/data/mdict/css/daijirin2.css
+++ b/data/mdict/css/daijirin2.css
@@ -1,7 +1,7 @@
 
 @font-face {
     font-family: jpgothic;
-    src: local("YuGothic"), local("Yu Gothic"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
+    src: local("YuGothic"), local("Yu Gothic Medium"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
 }
 
 @font-face {

--- a/data/mdict/css/daijirin2.css
+++ b/data/mdict/css/daijirin2.css
@@ -1,12 +1,12 @@
 
 @font-face {
     font-family: jpgothic;
-    src: local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
+    src: local("YuGothic"), local("Yu Gothic"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
 }
 
 @font-face {
     font-family: jpmincho;
-    src: local("Noto Serif CJK JP"), local("IPAexMincho"), local("IPAmjMincho"), local("Source Han Serif JP"), local("HanaMinA"), local("HanaMinB");
+    src: local("YuMincho"), local("Yu Mincho"), local("Noto Serif CJK JP"), local("IPAexMincho"), local("IPAmjMincho"), local("Source Han Serif JP"), local("HanaMinA"), local("HanaMinB");
 }
 
 body {

--- a/data/mdict/css/jitenon-kokugo.css
+++ b/data/mdict/css/jitenon-kokugo.css
@@ -1,7 +1,7 @@
 
 @font-face {
     font-family: jpgothic;
-    src: local("YuGothic"), local("Yu Gothic"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
+    src: local("YuGothic"), local("Yu Gothic Medium"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
 }
 
 @font-face {

--- a/data/mdict/css/jitenon-kokugo.css
+++ b/data/mdict/css/jitenon-kokugo.css
@@ -1,12 +1,12 @@
 
 @font-face {
     font-family: jpgothic;
-    src: local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
+    src: local("YuGothic"), local("Yu Gothic"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
 }
 
 @font-face {
     font-family: jpmincho;
-    src: local("Noto Serif CJK JP"), local("IPAexMincho"), local("IPAmjMincho"), local("Source Han Serif JP"), local("HanaMinA"), local("HanaMinB");
+    src: local("YuMincho"), local("Yu Mincho"), local("Noto Serif CJK JP"), local("IPAexMincho"), local("IPAmjMincho"), local("Source Han Serif JP"), local("HanaMinA"), local("HanaMinB");
 }
 
 body {

--- a/data/mdict/css/jitenon-kotowaza.css
+++ b/data/mdict/css/jitenon-kotowaza.css
@@ -1,7 +1,7 @@
 
 @font-face {
     font-family: jpgothic;
-    src: local("YuGothic"), local("Yu Gothic"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
+    src: local("YuGothic"), local("Yu Gothic Medium"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
 }
 
 @font-face {

--- a/data/mdict/css/jitenon-kotowaza.css
+++ b/data/mdict/css/jitenon-kotowaza.css
@@ -1,12 +1,12 @@
 
 @font-face {
     font-family: jpgothic;
-    src: local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
+    src: local("YuGothic"), local("Yu Gothic"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
 }
 
 @font-face {
     font-family: jpmincho;
-    src: local("Noto Serif CJK JP"), local("IPAexMincho"), local("IPAmjMincho"), local("Source Han Serif JP"), local("HanaMinA"), local("HanaMinB");
+    src: local("YuMincho"), local("Yu Mincho"), local("Noto Serif CJK JP"), local("IPAexMincho"), local("IPAmjMincho"), local("Source Han Serif JP"), local("HanaMinA"), local("HanaMinB");
 }
 
 body {

--- a/data/mdict/css/jitenon-yoji.css
+++ b/data/mdict/css/jitenon-yoji.css
@@ -1,7 +1,7 @@
 
 @font-face {
     font-family: jpgothic;
-    src: local("YuGothic"), local("Yu Gothic"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
+    src: local("YuGothic"), local("Yu Gothic Medium"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
 }
 
 @font-face {

--- a/data/mdict/css/jitenon-yoji.css
+++ b/data/mdict/css/jitenon-yoji.css
@@ -1,12 +1,12 @@
 
 @font-face {
     font-family: jpgothic;
-    src: local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
+    src: local("YuGothic"), local("Yu Gothic"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
 }
 
 @font-face {
     font-family: jpmincho;
-    src: local("Noto Serif CJK JP"), local("IPAexMincho"), local("IPAmjMincho"), local("Source Han Serif JP"), local("HanaMinA"), local("HanaMinB");
+    src: local("YuMincho"), local("Yu Mincho"), local("Noto Serif CJK JP"), local("IPAexMincho"), local("IPAmjMincho"), local("Source Han Serif JP"), local("HanaMinA"), local("HanaMinB");
 }
 
 body {

--- a/data/mdict/css/sankoku8.css
+++ b/data/mdict/css/sankoku8.css
@@ -1,12 +1,12 @@
 
 @font-face {
     font-family: jpgothic;
-    src: local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
+    src: local("YuGothic"), local("Yu Gothic"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
 }
 
 @font-face {
     font-family: jpmincho;
-    src: local("Noto Serif CJK JP"), local("IPAexMincho"), local("IPAmjMincho"), local("Source Han Serif JP"), local("HanaMinA"), local("HanaMinB");
+    src: local("YuMincho"), local("Yu Mincho"), local("Noto Serif CJK JP"), local("IPAexMincho"), local("IPAmjMincho"), local("Source Han Serif JP"), local("HanaMinA"), local("HanaMinB");
 }
 
 @font-face {

--- a/data/mdict/css/sankoku8.css
+++ b/data/mdict/css/sankoku8.css
@@ -1,7 +1,7 @@
 
 @font-face {
     font-family: jpgothic;
-    src: local("YuGothic"), local("Yu Gothic"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
+    src: local("YuGothic"), local("Yu Gothic Medium"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
 }
 
 @font-face {

--- a/data/mdict/css/smk8.css
+++ b/data/mdict/css/smk8.css
@@ -1,7 +1,7 @@
 
 @font-face {
     font-family: jpgothic;
-    src: local("YuGothic"), local("Yu Gothic"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
+    src: local("YuGothic"), local("Yu Gothic Medium"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
 }
 
 @font-face {

--- a/data/mdict/css/smk8.css
+++ b/data/mdict/css/smk8.css
@@ -1,12 +1,12 @@
 
 @font-face {
     font-family: jpgothic;
-    src: local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
+    src: local("YuGothic"), local("Yu Gothic"), local("Noto Sans CJK JP"), local("IPAexGothic"), local("Source Han Sans JP");
 }
 
 @font-face {
     font-family: jpmincho;
-    src: local("Noto Serif CJK JP"), local("IPAexMincho"), local("IPAmjMincho"), local("Source Han Serif JP"), local("HanaMinA"), local("HanaMinB");
+    src: local("YuMincho"), local("Yu Mincho"), local("Noto Serif CJK JP"), local("IPAexMincho"), local("IPAmjMincho"), local("Source Han Serif JP"), local("HanaMinA"), local("HanaMinB");
 }
 
 body {


### PR DESCRIPTION
The other fonts might not be installed by default but 游明朝/游ゴシック is shipped by default on both mac and windows. A variant with and without space need to be added because they are named differently in windows and mac for some reason.